### PR TITLE
fix newlines in terminal output

### DIFF
--- a/R/cqcp_filter.R
+++ b/R/cqcp_filter.R
@@ -121,7 +121,7 @@ cqcp_add_episode <- function(data, duration){
   n <- data[p_id == data[1]$p_id, .N]
   episode <- rep(1:ceiling(n/steps), each = steps)
   if(length(episode) != n) {
-    cat(cqcp_colourise("[CrowdQC+] Last episode in data shorter than specified duration.", "yellow"))
+    cat(cqcp_colourise("[CrowdQC+] Last episode in data shorter than specified duration.\n", "yellow"))
   }
   data <- data[, episode := episode[1:n], by = .(p_id)]
   return(data)
@@ -203,7 +203,7 @@ cqcp_m3 <- function(data, cutOff = 0.2, complete = FALSE, duration = NULL){
     # minimum would be so that cutOff refers to at least one value
     times <- data[data[, .I[1:2], p_id]$V1][1:2,time]
     if(lubridate::duration(duration)/(times[2]-times[1])*cutOff < 1) {
-      cat(cqcp_colourise("[CrowdQC+] Specified duration in 'cqcp_m3' is short considering cutOff and temporal resolution.", "yellow"))
+      cat(cqcp_colourise("[CrowdQC+] Specified duration in 'cqcp_m3' is short considering cutOff and temporal resolution.\n", "yellow"))
     }
     has_e <- cqcp_has_column(data, column = "episode")
     if(!has_e) data <- cqcp_add_episode(data, duration)
@@ -262,7 +262,7 @@ cqcp_m4 <- function(data, cutOff = 0.9, complete = FALSE, duration = NULL){
     # check for a meaningful sample size in correlation.
     sample <- data[, .N, p_id][1,N]
     if(sample < 100) {
-      cat(cqcp_colourise(paste0("[CrowdQC+] Small sample size (n=",sample,") for correlation in 'cqcp_m4' with this data set.", "yellow")))
+      cat(cqcp_colourise(paste0("[CrowdQC+] Small sample size (n=",sample,") for correlation in 'cqcp_m4' with this data set.\n", "yellow")))
     }
     data <- data[, episode := 1] # only one episode, the whole data set
     data_agg <- data[,.(med = median(rem_ta, na.rm = T)), by=.(episode, time)]
@@ -276,7 +276,7 @@ cqcp_m4 <- function(data, cutOff = 0.9, complete = FALSE, duration = NULL){
     times <- data[data[, .I[1:2], p_id]$V1][1:2,time]
     sample <- lubridate::duration(duration)/(times[2]-times[1])
     if(sample < 100) {
-      cat(cqcp_colourise(paste0("[CrowdQC+] Small sample size (n=",sample,") for correlation in 'cqcp_m4' with the specified duration.", "yellow")))
+      cat(cqcp_colourise(paste0("[CrowdQC+] Small sample size (n=",sample,") for correlation in 'cqcp_m4' with the specified duration.\n", "yellow")))
     }
     has_e <- cqcp_has_column(data, column = "episode")
     if(!has_e) data <- cqcp_add_episode(data, duration)
@@ -417,7 +417,7 @@ cqcp_m5 <- function(data, radius = 3000, n_buddies = 5, alpha = 0.1,
     }
     data[is.na(m5), m5 := FALSE]
   } else {
-    cat(cqcp_colourise("[CrowdQC+] QC level m5 could not meaningfully be performed with current configuration (too few buddies for all stations). Consider increasing the radius or decreasing the number of buddies.", "yellow"))
+    cat(cqcp_colourise("[CrowdQC+] QC level m5 could not meaningfully be performed with current configuration (too few buddies for all stations). Consider increasing the radius or decreasing the number of buddies.\n", "yellow"))
     data[, m5 := FALSE]
   }
   


### PR DESCRIPTION
The missing newlines slightly messed up my terminal (it moved the PS1 over to the side) because there were no newlines after the output (and there is no `\n` before my PS1 `PS1='PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '` which is the default).

I am not sure how the built in RStudio-Terminal handles this. In my case it was vanilla gnome terminal with bash on ubuntu.