### PR TITLE
Update to SRTM download, documentation update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,4 +23,4 @@ RoxygenNote: 7.2.1
 Depends: R (>= 3.5.0)
 Imports: data.table, methods, stats, robustbase, lubridate, sp, raster, rgdal, geodata
 NeedsCompilation: no
-Packaged: 2022-09-08 10:40 UTC; dafenner
+Packaged: 2022-09-08 12:45 UTC; dafenner

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: CrowdQCplus
 Type: Package
 Title: Enhanced quality control for crowdsourced data from citizen weather stations
-Version: 1.0.0
-Date: 2021-11-01
+Version: 1.0.1
+Date: 2022-09-08
 Author: Daniel Fenner, Tom Grassmann, Benjamin Bechtel, Matthias Demuzere, Jonas Kittner, Fred Meier
 Authors@R: c(
     person("Daniel", "Fenner", email = "daniel.fenner@meteo.uni-freiburg.de", role = c("aut", "cre")),
@@ -21,6 +21,6 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.2.1
 Depends: R (>= 3.5.0)
-Imports: data.table, methods, stats, robustbase, lubridate, sp, raster, rgdal
+Imports: data.table, methods, stats, robustbase, lubridate, sp, raster, rgdal, geodata
 NeedsCompilation: no
-Packaged: 2021-11-01 22:50 UTC; dafenner
+Packaged: 2022-09-08 10:40 UTC; dafenner

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Authors@R: c(
 Maintainer: Daniel Fenner <daniel.fenner@meteo.uni-freiburg.de>
 Description: This package performs a quality control (QC) and filters suspicious data from citizen weather stations (CWS). It was originally designed for and tested with hourly air-temperature data but should work with other near-normally distributed data. It is based on the package 'CrowdQC' but offers several additions and improvements.
 License: GPL-3 + file LICENCE
-Citation: Fenner et al. 2021
+Citation: Fenner et al. 2022
 URL: https://github.com/dafenner/CrowdQCplus
 BugReports: https://github.com/dafenner/CrowdQCplus/issues
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL: https://github.com/dafenner/CrowdQCplus
 BugReports: https://github.com/dafenner/CrowdQCplus/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Depends: R (>= 3.5.0)
 Imports: data.table, methods, stats, robustbase, lubridate, sp, raster, rgdal
 NeedsCompilation: no

--- a/R/cqcp_filter.R
+++ b/R/cqcp_filter.R
@@ -563,8 +563,14 @@ cqcp_o3 <- function(data, cutOff = 0.8, complete = FALSE, duration = NULL,
 #' In the correction the original data "ta" is used instead of the interpolated
 #' values "ta_int". Hence, this function can be applied at/after any QC level. 
 #' Diverging from all other QC levels, no additional flag variable with TRUE/FALSE 
-#' is added to the data.table during cqcp_o4. Data after the correction thus can be 
+#' is added to the data.table during cqcp_o4. Corrected data can thus be 
 #' selected at any QC level. The corrected data are written in a new column 'ta_corr'. 
+#' For Netatmo CWS (https://www.netatmo.com/en-us/weather), Coney et al. 2022 
+#' (https://doi.org/10.1002/met.2075) determined a mean time constant of the 
+#' air-temperature sensor of tau = 12.7 minutes (762 seconds).
+#' Büchau 2018 (MSc thesis, https://bis-erdsystem.de/fileadmin/user_upload/bise/Texte/MSC_Met_61-20180313.pdf)
+#' determined a mean time constant of the Netatmo air-temperature sensor (including 
+#' silver aluminium shell) of tau = 24.675 minutes (1480.5 seconds).
 #'
 #' @param data data.table in CrowdQC+ format (columns "time" and "ta" must be present)
 #' @param time_constant Time constant value for the sensor in seconds (must be 

--- a/R/cqcp_filter.R
+++ b/R/cqcp_filter.R
@@ -1,5 +1,5 @@
 # CrowdQC+ - Quality control for citizen weather station data.
-# Copyright (C) 2021  Daniel Fenner, Tom Grassmann, Benjamin Bechtel, Matthias Demuzere, Jonas Kittner, Fred Meier
+# Copyright (C) 2022  Daniel Fenner, Tom Grassmann, Benjamin Bechtel, Matthias Demuzere, Jonas Kittner, Fred Meier
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -565,12 +565,21 @@ cqcp_o3 <- function(data, cutOff = 0.8, complete = FALSE, duration = NULL,
 #' Diverging from all other QC levels, no additional flag variable with TRUE/FALSE 
 #' is added to the data.table during cqcp_o4. Corrected data can thus be 
 #' selected at any QC level. The corrected data are written in a new column 'ta_corr'. 
-#' For Netatmo CWS (https://www.netatmo.com/en-us/weather), Coney et al. 2022 
-#' (https://doi.org/10.1002/met.2075) determined a mean time constant of the 
-#' air-temperature sensor of tau = 12.7 minutes (762 seconds).
-#' Büchau 2018 (MSc thesis, https://bis-erdsystem.de/fileadmin/user_upload/bise/Texte/MSC_Met_61-20180313.pdf)
-#' determined a mean time constant of the Netatmo air-temperature sensor (including 
-#' silver aluminium shell) of tau = 24.675 minutes (1480.5 seconds).
+#' For Netatmo CWS (https://www.netatmo.com/en-us/weather), Coney et al. (2022) 
+#' determined a mean time constant of the air-temperature sensor of 
+#' tau = 12.7 minutes (762 seconds).
+#' Büchau (2018) determined a mean time constant of the Netatmo air-temperature 
+#' sensor (including silver aluminium shell) of tau = 24.675 minutes (1480.5 seconds).
+#' 
+#' References: 
+#' Büchau, Y. G. (2018): Modelling Shielded Temperature Sensors - An Assessment 
+#' of the Netatmo Citizen Weather Station. MSc Thesis, Universität Hamburg, Germany.
+#' Available at: https://bis-erdsystem.de/fileadmin/user_upload/bise/Texte/MSC_Met_61-20180313.pdf
+#' 
+#' Coney, J., Pickering, B., Dufton, D., Lukach, M., Brooks, B. and Neely, R. R. (2022):
+#' How useful are crowdsourced air temperature observations? An assessment of 
+#' Netatmo stations and quality control schemes over the United Kingdom. 
+#' Meteorol. Appl. 29 (3): e2075. https://doi.org/10.1002/met.2075
 #'
 #' @param data data.table in CrowdQC+ format (columns "time" and "ta" must be present)
 #' @param time_constant Time constant value for the sensor in seconds (must be 

--- a/R/cqcp_helper.R
+++ b/R/cqcp_helper.R
@@ -73,7 +73,7 @@ cqcp_check_input <- function(data, print = TRUE, file = NULL, as_list = FALSE){
     if(!has_ta) miss_1a <- c(miss_1a, "ta")
     if(!has_lon) miss_1a <- c(miss_1a, "lon")
     if(!has_lat) miss_1a <- c(miss_1a, "lat")
-    mess_1a <- cqcp_colourise(paste0("     ! Missing: ",paste(test, collapse = ", "),"\n     --> CrowdQC+ will not work with this data.\n"), "red")
+    mess_1a <- cqcp_colourise(paste0("     ! Missing: ", paste(miss_1a, collapse = ", "),"\n     --> CrowdQC+ will not work with this data.\n"), "red")
     ch_1a <- FALSE
     ok <- FALSE
   } else mess_1a <- cqcp_colourise("     OK\n", "green")
@@ -83,7 +83,7 @@ cqcp_check_input <- function(data, print = TRUE, file = NULL, as_list = FALSE){
   if(!has_z) {
     miss_1b <- c(miss_1b, "z")
     mess_1b <- cqcp_colourise("     ! Missing: z\n", "yellow")
-    mess_1b <- cqcp_colourise("     --> Filters cqcp_m2 and cqcp_m5 will not work with 'heightCorrection = T'. You can run 'cqcp_add_dem_height' to add DEM information.\n", "yellow")
+    mess_1b <- c(mess_1b, cqcp_colourise("     --> Filters cqcp_m2 and cqcp_m5 will not work with 'heightCorrection = T'. You can run 'cqcp_add_dem_height' to add DEM information.\n", "yellow"))
     ch_1b <- FALSE
   } else mess_1b <- cqcp_colourise("     OK\n", "green")
   

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ devtools::install_local(<PATH_TO_THE_ZIP_FILE>)
 
 **Option 3:**
 
-Download the latest release of CrowdQC+ as a `.tar.gz` file ([list or releases](https://github.com/dafenner/CrowdQCplus/releases)), save it locally, and install it in your programming environment:
+Download the latest release of CrowdQC+ as a `.tar.gz` file ([list of releases](https://github.com/dafenner/CrowdQCplus/releases)), save it locally, and install it in your programming environment:
 ```
 install.packages(<PATH_TO_THE_tar.gz_FILE>, repos = NULL, type ="source")
 ```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # CrowdQC+
 
-This R package performs a quality control (QC) and filters suspicious data from citizen weather stations (CWS). It is based on the package <a href="http://dx.doi.org/10.14279/depositonce-6740.3">'CrowdQC'</a> but offers several additions, improvements, and bug fixes. Both packages were originally designed for and tested with air-temperature data but should also work with other near-normally distributed data. It is not designed for precipitation data.
+This R package performs a quality control (QC) and filters suspicious data from citizen weather stations (CWS). It is based on the package ['CrowdQC'](http://dx.doi.org/10.14279/depositonce-6740.3) but offers several additions, improvements, and bug fixes. Both packages were originally designed for and tested with air-temperature data but should also work with other near-normally distributed data. It is not designed for precipitation data.
 
 CrowdQC+ is a statistically-based QC that identifies individual possibly faulty observations by comparing them to a large crowd of other observations. It does not need reference meteorological observations to be applied. The main idea of CrowdQC+ is that there is trustworthy information in the crowd, which can be used to check and remove individual values during the QC. Yet, there is no guarantee that all faulty observations are filtered by the QC.
 
-A detailed description of the functionalities and an evaluation of the performance of the QC can be found in this open-access journal article: CrowdQC+ – A quality-control for crowdsourced air-temperature observations enabling world-wide urban climate applications. Frontiers in Environmental Science.<br>
+A detailed description of the functionalities and an evaluation of the performance of the QC can be found in this open-access journal article: [CrowdQC+ – A quality-control for crowdsourced air-temperature observations enabling world-wide urban climate applications. Frontiers in Environmental Science](https://doi.org/10.3389/fenvs.2021.720747).<br>
 It is recommended that you read the article before you start working with CrowdQC+ to understand its capabilities and limitations.
 
 ## Dependencies
@@ -39,7 +39,7 @@ install.packages("rgdal", configure.args = c(rgdal = "--with-proj_api=proj_api.h
 
 **Option 1:**
 
-Directly pull the code from this repository into your programming environment, using the <a href="https://devtools.r-lib.org/">devtools</a> package:
+Directly pull the code from this repository into your programming environment, using the [devtools](https://devtools.r-lib.org/) package:
 
 ```
 install.packages("devtools")
@@ -48,7 +48,7 @@ devtools::install_github("dafenner/CrowdQCplus")
 
 **Option 2:**
 
-Download the <a href="https://github.com/dafenner/CrowdQCplus/archive/refs/heads/master.zip">zip-file</a> from this repository, save it locally, and install it in your programming environment using the <a href="https://devtools.r-lib.org/">devtools</a> package:
+Download the [zip-file](https://github.com/dafenner/CrowdQCplus/archive/refs/heads/master.zip) from this repository, save it locally, and install it in your programming environment using the [devtools](https://devtools.r-lib.org/) package:
 ```
 install.packages("devtools")
 devtools::install_local(<PATH_TO_THE_ZIP_FILE>)
@@ -56,7 +56,7 @@ devtools::install_local(<PATH_TO_THE_ZIP_FILE>)
 
 **Option 3:**
 
-Download the latest release of CrowdQC+ as a `.tar.gz` file <a href="https://github.com/dafenner/CrowdQCplus/releases"> (list or releases)</a>, save it locally, and install it in your programming environment:
+Download the latest release of CrowdQC+ as a `.tar.gz` file ([list or releases](https://github.com/dafenner/CrowdQCplus/releases)), save it locally, and install it in your programming environment:
 ```
 install.packages(<PATH_TO_THE_tar.gz_FILE>, repos = NULL, type ="source")
 ```
@@ -70,7 +70,7 @@ library(CrowdQCplus)
 
 ## Using CrowdQC+
 ### Data
-Data should be represented as a <a href="https://CRAN.R-project.org/package=data.table">data.table</a> with the following required columns:
+Data should be represented as a [data.table](https://CRAN.R-project.org/package=data.table) with the following required columns:
 
 `p_id`: unique ID of each station<br>
 `time`: time as POSIX.ct. Keep in mind time zones!<br>
@@ -127,19 +127,19 @@ if(ok) {
 ```
 
 ## How to contribute?
-If you are using CrowdQC+ and have ideas how to make it better, improve its performance, resolve errors, please create <a href="https://github.com/dafenner/CrowdQCplus/issues">issues</a>.
+If you are using CrowdQC+ and have ideas how to make it better, improve its performance, resolve errors, please create [issues](https://github.com/dafenner/CrowdQCplus/issues).
 
 ## How to obtain CWS data?
 To crowdsource CWS data different data providers with application programming interfaces (API) exist, each with advantages and disadvantages, e.g.:
-- <a href="https://www.netatmo.com/">Netatmo</a>: <a href="https://dev.netatmo.com/">Netatmo Connect API</a>
-- <a href="https://synopticdata.com/">Synoptic</a>: <a href="https://developers.synopticdata.com/mesonet/">Mesonet API</a>
-- <a href="https://www.wow.metoffice.gov.uk/">Weather Observations Website (WOW)</a>: <a href="https://mowowprod.portal.azure-api.net/">WOW API</a>
+- [Netatmo](https://www.netatmo.com/): [Netatmo Connect API](https://dev.netatmo.com/)
+- [Synoptic](https://synopticdata.com/): [Mesonet API](https://developers.synopticdata.com/mesonet/)
+- [Weather Observations Website (WOW)](https://www.wow.metoffice.gov.uk/): [WOW API](https://mowowprod.portal.azure-api.net/)
 
 ## Reference
 Please reference the following open-access journal article when using CrowdQC+:
 
-Fenner, D., Bechtel, B., Demuzere, M., Kittner, J. and Meier, F.: CrowdQC+ – A quality-control for crowdsourced air-temperature observations enabling world-wide urban climate applications. Frontiers in Environmental Science 9: 720747. DOI: [10.3389/fenvs.2021.720747](https://doi.org/10.3389/fenvs.2021.720747).
+Fenner, D., Bechtel, B., Demuzere, M., Kittner, J. and Meier, F. (2021): CrowdQC+ – A quality-control for crowdsourced air-temperature observations enabling world-wide urban climate applications. Frontiers in Environmental Science 9: 720747. DOI: [10.3389/fenvs.2021.720747](https://doi.org/10.3389/fenvs.2021.720747).
 
 ## Licence
-CrowdQC+ is distributed under the <a href="http://www.gnu.org/licenses/gpl-3.0.en.html">GNU General Public License v3</a>.
+CrowdQC+ is distributed under the [GNU General Public License v3](http://www.gnu.org/licenses/gpl-3.0.en.html).
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ To crowdsource CWS data different data providers with application programming in
 ## Reference
 Please reference the following open-access journal article when using CrowdQC+:
 
-Fenner, D., Bechtel, B., Demuzere, M., Kittner, J. and Meier, F.: CrowdQC+ – A quality-control for crowdsourced air-temperature observations enabling world-wide urban climate applications. Frontiers in Environmental Science.
+Fenner, D., Bechtel, B., Demuzere, M., Kittner, J. and Meier, F.: CrowdQC+ – A quality-control for crowdsourced air-temperature observations enabling world-wide urban climate applications. Frontiers in Environmental Science 9: 720747. DOI: [10.3389/fenvs.2021.720747](https://doi.org/10.3389/fenvs.2021.720747).
 
 ## Licence
 CrowdQC+ is distributed under the <a href="http://www.gnu.org/licenses/gpl-3.0.en.html">GNU General Public License v3</a>.

--- a/man/cqcp_add_dem_height.Rd
+++ b/man/cqcp_add_dem_height.Rd
@@ -38,7 +38,7 @@ cqcp_m2. Default: 0}
 
 \item{quiet}{Suppress messages by CrowdQC+. Default: FALSE}
 
-\item{...}{Additional parameters supported by raster::getData}
+\item{...}{Additional parameters supported by geodata::elevation_3s}
 }
 \value{
 data table with new column 'z' with DEM information

--- a/man/cqcp_download_srtm.Rd
+++ b/man/cqcp_download_srtm.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/cqcp_helper.R
 \name{cqcp_download_srtm}
 \alias{cqcp_download_srtm}
-\title{Download SRTM data using raster package for bounding box of data.}
+\title{Download SRTM data using geodata package for bounding box of data.}
 \usage{
 cqcp_download_srtm(
   data,
@@ -25,7 +25,7 @@ downloaded data is stored in the current working directory.}
 
 \item{crop}{Crop raster/geotiff to data extent? Default is FALSE.}
 
-\item{...}{Additional parameters supported by raster::getData}
+\item{...}{Additional parameters supported by geodata::elevation_3s}
 }
 \value{
 RasterLayer object with SRTM data

--- a/man/cqcp_o4.Rd
+++ b/man/cqcp_o4.Rd
@@ -30,10 +30,20 @@ values "ta_int". Hence, this function can be applied at/after any QC level.
 Diverging from all other QC levels, no additional flag variable with TRUE/FALSE 
 is added to the data.table during cqcp_o4. Corrected data can thus be 
 selected at any QC level. The corrected data are written in a new column 'ta_corr'. 
-For Netatmo CWS (https://www.netatmo.com/en-us/weather), Coney et al. 2022 
-(https://doi.org/10.1002/met.2075) determined a mean time constant of the 
-air-temperature sensor of tau = 12.7 minutes (762 seconds).
-Büchau 2018 (MSc thesis, https://bis-erdsystem.de/fileadmin/user_upload/bise/Texte/MSC_Met_61-20180313.pdf)
-determined a mean time constant of the Netatmo air-temperature sensor (including 
-silver aluminium shell) of tau = 24.675 minutes (1480.5 seconds).
+For Netatmo CWS (https://www.netatmo.com/en-us/weather), Coney et al. (2022) 
+determined a mean time constant of the air-temperature sensor of 
+tau = 12.7 minutes (762 seconds).
+Büchau (2018) determined a mean time constant of the Netatmo air-temperature 
+sensor (including silver aluminium shell) of tau = 24.675 minutes (1480.5 seconds).
+}
+\details{
+References: 
+Büchau, Y. G. (2018): Modelling Shielded Temperature Sensors - An Assessment 
+of the Netatmo Citizen Weather Station. MSc Thesis, Universität Hamburg, Germany.
+Available at: https://bis-erdsystem.de/fileadmin/user_upload/bise/Texte/MSC_Met_61-20180313.pdf
+
+Coney, J., Pickering, B., Dufton, D., Lukach, M., Brooks, B. and Neely, R. R. (2022):
+How useful are crowdsourced air temperature observations? An assessment of 
+Netatmo stations and quality control schemes over the United Kingdom. 
+Meteorol. Appl. 29 (3): e2075. https://doi.org/10.1002/met.2075
 }

--- a/man/cqcp_o4.Rd
+++ b/man/cqcp_o4.Rd
@@ -28,6 +28,12 @@ step to the next.
 In the correction the original data "ta" is used instead of the interpolated
 values "ta_int". Hence, this function can be applied at/after any QC level. 
 Diverging from all other QC levels, no additional flag variable with TRUE/FALSE 
-is added to the data.table during cqcp_o4. Data after the correction thus can be 
-selected at any QC level. The corrected data are written in a new column 'ta_corr'.
+is added to the data.table during cqcp_o4. Corrected data can thus be 
+selected at any QC level. The corrected data are written in a new column 'ta_corr'. 
+For Netatmo CWS (https://www.netatmo.com/en-us/weather), Coney et al. 2022 
+(https://doi.org/10.1002/met.2075) determined a mean time constant of the 
+air-temperature sensor of tau = 12.7 minutes (762 seconds).
+Büchau 2018 (MSc thesis, https://bis-erdsystem.de/fileadmin/user_upload/bise/Texte/MSC_Met_61-20180313.pdf)
+determined a mean time constant of the Netatmo air-temperature sensor (including 
+silver aluminium shell) of tau = 24.675 minutes (1480.5 seconds).
 }


### PR DESCRIPTION
- updated automatic SRTM download in cqcp_add_dem_height/cqcp_download_srtm with the `geodata` package instead of `raster` package (#27).
- included published time constants in documentation of `cqcp_o4` (#25)