### PR TITLE
Remove dependencies of `raster` and `sp` packages/rgdal`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: CrowdQCplus
 Type: Package
 Title: Enhanced quality control for crowdsourced data from citizen weather stations
 Version: 1.1.0
-Date: 2023-07-04
+Date: 2023-07-11
 Author: Daniel Fenner, Tom Grassmann, Benjamin Bechtel, Matthias Demuzere, Jonas Kittner, Fred Meier
 Authors@R: c(
     person("Daniel", "Fenner", email = "daniel.fenner@meteo.uni-freiburg.de", role = c("aut", "cre")),
@@ -21,7 +21,6 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.2.3
 Depends: R (>= 3.5.0)
-# Imports: data.table, methods, stats, robustbase, lubridate, sp, raster, rgdal, geodata
 Imports: data.table, methods, stats, robustbase, lubridate, terra, geodata
 NeedsCompilation: no
-Packaged: 2023-07-04 16:05 UTC; dafenner
+Packaged: 2023-07-11 8:00 UTC; dafenner

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: CrowdQCplus
 Type: Package
 Title: Enhanced quality control for crowdsourced data from citizen weather stations
-Version: 1.0.2
-Date: 2023-06-08
+Version: 1.1.0
+Date: 2023-07-04
 Author: Daniel Fenner, Tom Grassmann, Benjamin Bechtel, Matthias Demuzere, Jonas Kittner, Fred Meier
 Authors@R: c(
     person("Daniel", "Fenner", email = "daniel.fenner@meteo.uni-freiburg.de", role = c("aut", "cre")),
@@ -21,6 +21,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.2.3
 Depends: R (>= 3.5.0)
-Imports: data.table, methods, stats, robustbase, lubridate, sp, raster, rgdal, geodata
+# Imports: data.table, methods, stats, robustbase, lubridate, sp, raster, rgdal, geodata
+Imports: data.table, methods, stats, robustbase, lubridate, terra, geodata
 NeedsCompilation: no
-Packaged: 2023-06-08 12:55 UTC; dafenner
+Packaged: 2023-07-04 15:55 UTC; dafenner

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Authors@R: c(
 Maintainer: Daniel Fenner <daniel.fenner@meteo.uni-freiburg.de>
 Description: This package performs a quality control (QC) and filters suspicious data from citizen weather stations (CWS). It was originally designed for and tested with hourly air-temperature data but should work with other near-normally distributed data. It is based on the package 'CrowdQC' but offers several additions and improvements.
 License: GPL-3 + file LICENCE
-Citation: Fenner et al. 2022
+Citation: Fenner et al. 2023
 URL: https://github.com/dafenner/CrowdQCplus
 BugReports: https://github.com/dafenner/CrowdQCplus/issues
 Encoding: UTF-8
@@ -24,4 +24,4 @@ Depends: R (>= 3.5.0)
 # Imports: data.table, methods, stats, robustbase, lubridate, sp, raster, rgdal, geodata
 Imports: data.table, methods, stats, robustbase, lubridate, terra, geodata
 NeedsCompilation: no
-Packaged: 2023-07-04 15:55 UTC; dafenner
+Packaged: 2023-07-04 16:05 UTC; dafenner

--- a/R/cqcp_filter.R
+++ b/R/cqcp_filter.R
@@ -361,7 +361,8 @@ cqcp_m5 <- function(data, radius = 3000, n_buddies = 5, alpha = 0.1,
   # calculate distances between stations and get relevant stations
   loc <- data[, .SD[1], by = p_id, .SDcols = get_cols]
   setkey(loc, p_id)
-  dist <- raster::pointDistance(loc[,c("lon", "lat")], lonlat=TRUE) # calculate distances between points
+  #dist <- raster::pointDistance(loc[,c("lon", "lat")], lonlat=TRUE) # calculate distances between points  - OLD VERSION with raster
+  dist <- as.matrix(terra::distance(as.matrix(loc[,c("lon", "lat")]), lonlat = TRUE)) # calculate distances between points
   colnames(dist) <- loc$p_id
   rownames(dist) <- loc$p_id
   dist <- as.data.table(as.table(dist))

--- a/R/cqcp_filter.R
+++ b/R/cqcp_filter.R
@@ -361,7 +361,6 @@ cqcp_m5 <- function(data, radius = 3000, n_buddies = 5, alpha = 0.1,
   # calculate distances between stations and get relevant stations
   loc <- data[, .SD[1], by = p_id, .SDcols = get_cols]
   setkey(loc, p_id)
-  #dist <- raster::pointDistance(loc[,c("lon", "lat")], lonlat=TRUE) # calculate distances between points  - OLD VERSION with raster
   dist <- as.matrix(terra::distance(as.matrix(loc[,c("lon", "lat")]), lonlat = TRUE)) # calculate distances between points
   colnames(dist) <- loc$p_id
   rownames(dist) <- loc$p_id

--- a/R/cqcp_helper.R
+++ b/R/cqcp_helper.R
@@ -88,7 +88,7 @@ cqcp_check_input <- function(data, print = TRUE, file = NULL, as_list = FALSE){
   } else mess_1b <- cqcp_colourise("     OK\n", "green")
   # (1c) Check for correct data type
   if (has_p_id) type_p_id <- (is.integer(data$p_id) | is.character(data$p_id)) else type_p_id <- FALSE
-  if (has_time) type_time <- is.POSIXct(data$time) else type_time <- FALSE
+  if (has_time) type_time <- lubridate::is.POSIXct(data$time) else type_time <- FALSE
   if (has_ta) type_ta <- is.numeric(data$ta) else type_ta <- FALSE
   if (has_lon) type_lon <- is.numeric(data$lon) else type_lon <- FALSE
   if (has_lat) type_lat <- is.numeric(data$lat) else type_lat <- FALSE
@@ -285,7 +285,7 @@ cqcp_extract_raster_data <- function(lon, lat, raster = NULL, file = NULL){
   
   # Convert lon/lat to "SpatialPoints"
   coords <- data.frame(lon=lon, lat=lat)
-  #coords <- sp::SpatialPoints(coords, proj4string = raster::crs("+init=epsg:4326")) # WGS-84 - OLD VERSION using sp
+  # coords <- sp::SpatialPoints(coords, proj4string = raster::crs("+init=epsg:4326")) # WGS-84 - OLD VERSION using sp
   coords <- terra::vect(coords, crs = "EPSG:4326") # WGS-84
   
   # Transform to CRS of raster
@@ -321,7 +321,7 @@ cqcp_extract_raster_data <- function(lon, lat, raster = NULL, file = NULL){
 #'    Default: "-k"
 #' @param ... Additional parameters supported by geodata::elevation_3s
 #'
-#' @return RasterLayer object with SRTM data
+#' @return SpatRaster object with SRTM data
 #' @export
 cqcp_download_srtm <- function(data, directory = NULL, outfile = NULL, 
                                overwrite = TRUE, crop = FALSE, 
@@ -343,10 +343,10 @@ cqcp_download_srtm <- function(data, directory = NULL, outfile = NULL,
   # lr <- raster::raster(geodata::elevation_3s(lat=min_lat, lon=max_lon, path = directory, ...))
   # ur <- raster::raster(geodata::elevation_3s(lat=max_lat, lon=max_lon, path = directory, ...))
   # ul <- raster::raster(geodata::elevation_3s(lat=max_lat, lon=min_lon, path = directory, ...))
-  ll <- geodata::elevation_3s(lat=min_lat, lon=min_lon, path = directory, method = method, extra = extra, ...)
-  lr <- geodata::elevation_3s(lat=min_lat, lon=max_lon, path = directory, method = method, extra = extra, ...)
-  ur <- geodata::elevation_3s(lat=max_lat, lon=max_lon, path = directory, method = method, extra = extra, ...)
-  ul <- geodata::elevation_3s(lat=max_lat, lon=min_lon, path = directory, method = method, extra = extra, ...)
+  ll <- geodata::elevation_3s(lat = min_lat, lon = min_lon, path = directory, method = method, extra = extra, ...)
+  lr <- geodata::elevation_3s(lat = min_lat, lon = max_lon, path = directory, method = method, extra = extra, ...)
+  ur <- geodata::elevation_3s(lat = max_lat, lon = max_lon, path = directory, method = method, extra = extra, ...)
+  ul <- geodata::elevation_3s(lat = max_lat, lon = min_lon, path = directory, method = method, extra = extra, ...)
   
   # Combine tiles, if necessary
   # mosaic <- raster::mosaic(ll, lr, ur, ul, fun=mean) - OLD VERSION using raster
@@ -432,7 +432,7 @@ cqcp_add_dem_height <- function(data, file = NULL, raster = NULL,
   
   # Put information back together
   locations <- cbind(locations, z = height)
-  data_out <- merge(data, locations[,.(p_id, z)], all.x = T, by = "p_id", sort = FALSE)
+  data_out <- merge(data, locations[, .(p_id, z)], all.x = T, by = "p_id", sort = FALSE)
   
   return(data_out)
 }

--- a/R/cqcp_helper.R
+++ b/R/cqcp_helper.R
@@ -158,7 +158,8 @@ cqcp_check_input <- function(data, print = TRUE, file = NULL, as_list = FALSE){
   if(has_p_id & has_lon & has_lon) {
     p_id <- unique(data$p_id)
     loc <- data[, .SD[1], by = p_id, .SDcols = c("lon", "lat")][,c("lon", "lat")]
-    dist <- raster::pointDistance(loc, lonlat=TRUE) # calculate distances between points
+    # dist <- raster::pointDistance(loc, lonlat=TRUE) # calculate distances between points - OLD VERSION with raster
+    dist <- as.matrix(terra::distance(as.matrix(loc), lonlat = TRUE)) # calculate distances between points
     max_dist <- max(dist, na.rm = T)
     if(max_dist > 141421.4) {
       mess_4 <- cqcp_colourise("     ! Geographic extent is large (> 100 km x 100 km).\n     --> You might want to split your data into smaller regions.\n", "yellow")
@@ -263,12 +264,12 @@ cqcp_check_input <- function(data, print = TRUE, file = NULL, as_list = FALSE){
   } else return(ok)
 }
 
-#' Extract raster value at given position(s) for a RasterLayer Object or geotiff
+#' Extract raster value(s) at given position(s) from a SpatRaster object or geotiff
 #' file.
 #'
 #' @param lon Longitude values(s)
 #' @param lat Latitude values(s) 
-#' @param raster RasterLayer object (cf. raster package) 
+#' @param raster SpatRaster object (cf. terra package) 
 #' @param file Path to a geotiff file
 #'
 #' @return extracted value(s) for given lon/lat
@@ -278,18 +279,22 @@ cqcp_extract_raster_data <- function(lon, lat, raster = NULL, file = NULL){
   if(!is.null(raster)) {
     gtiff <- raster
   } else if(!is.null(file)) {
-    gtiff <- raster::raster(file) # Open GeoTIFF
+    # gtiff <- raster::raster(file) # Open GeoTIFF - OLD VERSION using raster
+    gtiff <- terra::rast(file) # Open GeoTIFF
   } else stop("[CrowdQC+] No input given as 'file' or 'raster'.")
   
   # Convert lon/lat to "SpatialPoints"
   coords <- data.frame(lon=lon, lat=lat)
-  coords <- sp::SpatialPoints(coords, proj4string = raster::crs("+init=epsg:4326")) # WGS-84
+  #coords <- sp::SpatialPoints(coords, proj4string = raster::crs("+init=epsg:4326")) # WGS-84 - OLD VERSION using sp
+  coords <- terra::vect(coords, crs = "EPSG:4326") # WGS-84
   
   # Transform to CRS of raster
-  coords <- sp::spTransform(coords, raster::crs(gtiff))
+  # coords <- sp::spTransform(coords, raster::crs(gtiff)) - OLD VERSION using sp and raster
+  coords <- terra::project(coords, terra::crs(gtiff))
   
   # Extract data for each location
-  value <- raster::extract(gtiff, coords)
+  # value <- raster::extract(gtiff, coords) # OLD VERSION using raster
+  value <- as.numeric(terra::extract(gtiff, coords, ID = FALSE, raw = TRUE))
   
   return(value) # Output
 }
@@ -298,7 +303,7 @@ cqcp_extract_raster_data <- function(lon, lat, raster = NULL, file = NULL){
 #' 
 #' SRTM data is automatically downloaded and, in case of more than one SRTM tile, 
 #' merged together as a mosaic.
-#' The SRTM RasterLayer Object can be cropped to the geographical extent of 
+#' The SRTM SpatRaster object can be cropped to the geographical extent of 
 #' the data (crop = TRUE).
 #' SRTM source: https://srtm.csi.cgiar.org/
 #'
@@ -308,12 +313,19 @@ cqcp_extract_raster_data <- function(lon, lat, raster = NULL, file = NULL){
 #' @param outfile File path to save the SRTM raster as geotiff 
 #' @param overwrite Overwrite existing geotiff? Default is TRUE. 
 #' @param crop Crop raster/geotiff to data extent? Default is FALSE. 
+#' @param method Download method for geodata::elevation_3s. Use default here to 
+#'    avoid SSL certificate issues (cf. https://github.com/rspatial/geodata/issues/39#issuecomment-1404513208). 
+#'    Default: "curl".
+#' @param extra Additional keyword for "curl" method. Use default here to avoid SSL
+#'    certificate issues (cf. https://github.com/rspatial/geodata/issues/39#issuecomment-1404513208). 
+#'    Default: "-k"
 #' @param ... Additional parameters supported by geodata::elevation_3s
 #'
 #' @return RasterLayer object with SRTM data
 #' @export
 cqcp_download_srtm <- function(data, directory = NULL, outfile = NULL, 
-                               overwrite = TRUE, crop = FALSE, ...){
+                               overwrite = TRUE, crop = FALSE, 
+                               method = "curl", extra = "-k", ...){
   
   # Check if directory exists
   if(!is.null(directory)) {
@@ -327,25 +339,33 @@ cqcp_download_srtm <- function(data, directory = NULL, outfile = NULL,
   max_lat <- max(data$lat)
   
   # Download data
-  ll <- raster::raster(geodata::elevation_3s(lat=min_lat, lon=min_lon, path = directory, ...))
-  lr <- raster::raster(geodata::elevation_3s(lat=min_lat, lon=max_lon, path = directory, ...))
-  ur <- raster::raster(geodata::elevation_3s(lat=max_lat, lon=max_lon, path = directory, ...))
-  ul <- raster::raster(geodata::elevation_3s(lat=max_lat, lon=min_lon, path = directory, ...))
+  # ll <- raster::raster(geodata::elevation_3s(lat=min_lat, lon=min_lon, path = directory, ...))
+  # lr <- raster::raster(geodata::elevation_3s(lat=min_lat, lon=max_lon, path = directory, ...))
+  # ur <- raster::raster(geodata::elevation_3s(lat=max_lat, lon=max_lon, path = directory, ...))
+  # ul <- raster::raster(geodata::elevation_3s(lat=max_lat, lon=min_lon, path = directory, ...))
+  ll <- geodata::elevation_3s(lat=min_lat, lon=min_lon, path = directory, method = method, extra = extra, ...)
+  lr <- geodata::elevation_3s(lat=min_lat, lon=max_lon, path = directory, method = method, extra = extra, ...)
+  ur <- geodata::elevation_3s(lat=max_lat, lon=max_lon, path = directory, method = method, extra = extra, ...)
+  ul <- geodata::elevation_3s(lat=max_lat, lon=min_lon, path = directory, method = method, extra = extra, ...)
   
   # Combine tiles, if necessary
-  mosaic <- raster::mosaic(ll, lr, ur, ul, fun=mean)
+  # mosaic <- raster::mosaic(ll, lr, ur, ul, fun=mean) - OLD VERSION using raster
+  mosaic <- terra::mosaic(ll, lr, ur, ul, fun=mean)
   
   # Crop to data extent
   if(crop) {
-    data_extent <- as(raster::extent(min_lon, max_lon, min_lat, max_lat), 'SpatialPolygons')
-    raster::crs(data_extent) <- raster::crs(mosaic)
-    mosaic <- raster::crop(mosaic, data_extent)
+    # data_extent <- as(raster::extent(min_lon, max_lon, min_lat, max_lat), 'SpatialPolygons')
+    # raster::crs(data_extent) <- raster::crs(mosaic)
+    # mosaic <- raster::crop(mosaic, data_extent)
+    data_extent <- terra::ext(min_lon, max_lon, min_lat, max_lat)
+    mosaic <- terra::crop(mosaic, data_extent)
   }
   
   # Store merged raster?
   if(!is.null(outfile)) {
     if(!dir.exists(dirname(outfile))) dir.create(dirname(outfile))
-    raster::writeRaster(mosaic, filename = outfile, overwrite = overwrite)
+    # raster::writeRaster(mosaic, filename = outfile, overwrite = overwrite) - OLD VERSION using raster
+    terra::writeRaster(mosaic, filename = outfile, overwrite = overwrite)
   }
   
   return(mosaic)
@@ -353,15 +373,15 @@ cqcp_download_srtm <- function(data, directory = NULL, outfile = NULL,
 
 #' Add DEM height to data.table.
 #' 
-#' Adds Digital Elevation Model (DEM) information from a RasterLayer Object or 
+#' Adds Digital Elevation Model (DEM) information from a SptaRaster object or 
 #' geotiff to the data.table.
-#' If no RasterLayer Object or file are given as parameters, SRTM data 
+#' If no SptaRaster object or file are given as parameters, SRTM data 
 #' (Jarvis et al. 2008) is automatically downloaded and used to extract DEM 
 #' information at the positions of the stations. Keep in mind that SRTM data is 
 #' only available for regions between 60° N and 56° S. For regions outside that 
 #' range, or if the user wants to use another DEM, that DEM can be used as input 
 #' via the 'file' parameter (path to geotiff) or via the 'raster' parameter 
-#' (RasterLayer Object).
+#' (SpatRaster object).
 #' 
 #' A new column 'z' is added to the data.table to be used in QC level m2.
 #' 
@@ -372,7 +392,7 @@ cqcp_download_srtm <- function(data, directory = NULL, outfile = NULL,
 #'
 #' @param data data.table/frame with at least columns 'lon' and 'lat' 
 #' @param file Path to a DEM geotiff 
-#' @param raster RasterLayer object with DEM data 
+#' @param raster SpatRaster object with DEM data 
 #' @param directory Directory path to store the downloaded SRTM data. If NULL,
 #'   downloaded data is stored in the current working directory. 
 #' @param outfile File path to save the created SRTM raster as geotiff 
@@ -408,7 +428,7 @@ cqcp_add_dem_height <- function(data, file = NULL, raster = NULL,
                                      raster = raster, file = file)
   
   # deal with NA values
-  height[is.na(height)] <- na_vals
+  height[is.na(height)] <- na_vals # should we change to default NA?
   
   # Put information back together
   locations <- cbind(locations, z = height)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This R package performs a quality control (QC) and filters suspicious data from citizen weather stations (CWS). It is based on the package ['CrowdQC'](http://dx.doi.org/10.14279/depositonce-6740.3) but offers several additions, improvements, and bug fixes. Both packages were originally designed for and tested with air-temperature data but should also work with other near-normally distributed data. It is not designed for precipitation data.
 
-CrowdQC+ is a statistically-based QC that identifies individual possibly faulty observations by comparing them to a large crowd of other observations. It does not need reference meteorological observations to be applied. The main idea of CrowdQC+ is that there is trustworthy information in the crowd, which can be used to check and remove individual values during the QC. Yet, there is no guarantee that all faulty observations are filtered by the QC.
+CrowdQC+ is a statistically-based QC that identifies individual possibly faulty observations by comparing them to a large crowd of other observations. It does not need reference meteorological observations. The main idea of CrowdQC+ is that there is trustworthy information in the crowd, which can be used to check and remove individual values during the QC. Yet, there is no guarantee that all faulty observations are filtered by the QC.
 
 A detailed description of the functionalities and an evaluation of the performance of the QC can be found in this open-access journal article: [CrowdQC+ – A quality-control for crowdsourced air-temperature observations enabling world-wide urban climate applications. Frontiers in Environmental Science](https://doi.org/10.3389/fenvs.2021.720747).<br>
 It is recommended that you read the article before you start working with CrowdQC+ to understand its capabilities and limitations.
@@ -12,28 +12,18 @@ CrowdQC+ requires an R version >= 3.5.0 to work.
 
 It also requires the following packages: 
 - data.table
+- methods
+- stats
 - robustbase
 - lubridate
-- sp
-- raster
-- rgdal
+- terra
+- geodata
 
 Make sure to have these installed (and 'data.table' needs to be loaded) before running CrowdQC+.
 
-When installing 'rgdal' package on a Linux system, you might run into issues. Try running 
-```
-sudo apt-get install gdal-bin proj-bin libgdal-dev libproj-dev
-```
+## Update for version v1.1
+CrowdQC+ now uses the `terra` package for the geospatial components instead of the older packages `raster` and `sp`, which are based on (soon-to-be) retired `rgdal`.
 
-first and then again installing rgdal in R with 
-```
-install.packages("rgdal")
-```
-
-For 'older' Linux versions this could also work: 
-```
-install.packages("rgdal", configure.args = c(rgdal = "--with-proj_api=proj_api.h"))
-```
 
 ## Installation of the package
 
@@ -75,8 +65,8 @@ Data should be represented as a [data.table](https://CRAN.R-project.org/package=
 `p_id`: Unique ID of each station. Data format: Integer or character<br>
 `time`: Time. Keep in mind time zones! Data format: POSIX.ct<br>
 `ta`: Air-temperature values (or other near-normally distributed variable). Data format: Numeric/double<br>
-`lon`: Longitude of the station. Data format: Numeric/double<br>
-`lat`: Latitude of the station. Data format: Numeric/double<br>
+`lon`: Longitude of the station (WGS 84). Data format: Numeric/double<br>
+`lat`: Latitude of the station (WGS 84). Data format: Numeric/double<br>
 
 Optionally, the user can provide elevation information per station (column `z`), as to perform a height correction in some of the QC levels.
 Any other column can be present, but is quietly ignored by CrowdQC+.

--- a/man/cqcp_add_dem_height.Rd
+++ b/man/cqcp_add_dem_height.Rd
@@ -14,6 +14,7 @@ cqcp_add_dem_height(
   crop = FALSE,
   na_vals = 0,
   quiet = FALSE,
+  overwrite_z = TRUE,
   ...
 )
 }
@@ -29,24 +30,26 @@ downloaded data is stored in the current working directory.}
 
 \item{outfile}{File path to save the created SRTM raster as geotiff}
 
-\item{overwrite}{overwrite existing geotiff?}
+\item{overwrite}{Overwrite existing geotiff? Default: TRUE.}
 
-\item{crop}{Crop SRTM raster/geotiff to data extent}
+\item{crop}{Crop SRTM raster/geotiff to data extent. Default: FALSE.}
 
 \item{na_vals}{Set NA values in DEM to this value to avoid missing value in 
 cqcp_m2. Default: 0}
 
 \item{quiet}{Suppress messages by CrowdQC+. Default: FALSE}
 
+\item{overwrite_z}{If column 'z' exists in data, should it be overwritten? Default: TRUE.}
+
 \item{...}{Additional parameters supported by geodata::elevation_3s}
 }
 \value{
-data table with new column 'z' with DEM information
+data table with column 'z' with DEM information
 }
 \description{
-Adds Digital Elevation Model (DEM) information from a SptaRaster object or 
+Adds Digital Elevation Model (DEM) information from a SpatRaster object or 
 geotiff to the data.table.
-If no SptaRaster object or file are given as parameters, SRTM data 
+If no SpatRaster object or file are given as parameters, SRTM data 
 (Jarvis et al. 2008) is automatically downloaded and used to extract DEM 
 information at the positions of the stations. Keep in mind that SRTM data is 
 only available for regions between 60° N and 56° S. For regions outside that 

--- a/man/cqcp_add_dem_height.Rd
+++ b/man/cqcp_add_dem_height.Rd
@@ -22,7 +22,7 @@ cqcp_add_dem_height(
 
 \item{file}{Path to a DEM geotiff}
 
-\item{raster}{RasterLayer object with DEM data}
+\item{raster}{SpatRaster object with DEM data}
 
 \item{directory}{Directory path to store the downloaded SRTM data. If NULL,
 downloaded data is stored in the current working directory.}
@@ -44,15 +44,15 @@ cqcp_m2. Default: 0}
 data table with new column 'z' with DEM information
 }
 \description{
-Adds Digital Elevation Model (DEM) information from a RasterLayer Object or 
+Adds Digital Elevation Model (DEM) information from a SptaRaster object or 
 geotiff to the data.table.
-If no RasterLayer Object or file are given as parameters, SRTM data 
+If no SptaRaster object or file are given as parameters, SRTM data 
 (Jarvis et al. 2008) is automatically downloaded and used to extract DEM 
 information at the positions of the stations. Keep in mind that SRTM data is 
 only available for regions between 60° N and 56° S. For regions outside that 
 range, or if the user wants to use another DEM, that DEM can be used as input 
 via the 'file' parameter (path to geotiff) or via the 'raster' parameter 
-(RasterLayer Object).
+(SpatRaster object).
 }
 \details{
 A new column 'z' is added to the data.table to be used in QC level m2.

--- a/man/cqcp_download_srtm.Rd
+++ b/man/cqcp_download_srtm.Rd
@@ -38,7 +38,7 @@ Default: "-k"}
 \item{...}{Additional parameters supported by geodata::elevation_3s}
 }
 \value{
-RasterLayer object with SRTM data
+SpatRaster object with SRTM data
 }
 \description{
 SRTM data is automatically downloaded and, in case of more than one SRTM tile, 

--- a/man/cqcp_download_srtm.Rd
+++ b/man/cqcp_download_srtm.Rd
@@ -10,6 +10,8 @@ cqcp_download_srtm(
   outfile = NULL,
   overwrite = TRUE,
   crop = FALSE,
+  method = "curl",
+  extra = "-k",
   ...
 )
 }
@@ -25,6 +27,14 @@ downloaded data is stored in the current working directory.}
 
 \item{crop}{Crop raster/geotiff to data extent? Default is FALSE.}
 
+\item{method}{Download method for geodata::elevation_3s. Use default here to 
+avoid SSL certificate issues (cf. https://github.com/rspatial/geodata/issues/39#issuecomment-1404513208). 
+Default: "curl".}
+
+\item{extra}{Additional keyword for "curl" method. Use default here to avoid SSL
+certificate issues (cf. https://github.com/rspatial/geodata/issues/39#issuecomment-1404513208). 
+Default: "-k"}
+
 \item{...}{Additional parameters supported by geodata::elevation_3s}
 }
 \value{
@@ -33,7 +43,7 @@ RasterLayer object with SRTM data
 \description{
 SRTM data is automatically downloaded and, in case of more than one SRTM tile, 
 merged together as a mosaic.
-The SRTM RasterLayer Object can be cropped to the geographical extent of 
+The SRTM SpatRaster object can be cropped to the geographical extent of 
 the data (crop = TRUE).
 SRTM source: https://srtm.csi.cgiar.org/
 }

--- a/man/cqcp_download_srtm.Rd
+++ b/man/cqcp_download_srtm.Rd
@@ -23,9 +23,9 @@ downloaded data is stored in the current working directory.}
 
 \item{outfile}{File path to save the SRTM raster as geotiff}
 
-\item{overwrite}{Overwrite existing geotiff? Default is TRUE.}
+\item{overwrite}{Overwrite existing geotiff? Default: TRUE.}
 
-\item{crop}{Crop raster/geotiff to data extent? Default is FALSE.}
+\item{crop}{Crop raster/geotiff to data extent? Default: FALSE.}
 
 \item{method}{Download method for geodata::elevation_3s. Use default here to 
 avoid SSL certificate issues (cf. https://github.com/rspatial/geodata/issues/39#issuecomment-1404513208). 

--- a/man/cqcp_extract_raster_data.Rd
+++ b/man/cqcp_extract_raster_data.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/cqcp_helper.R
 \name{cqcp_extract_raster_data}
 \alias{cqcp_extract_raster_data}
-\title{Extract raster value at given position(s) for a RasterLayer Object or geotiff
+\title{Extract raster value(s) at given position(s) from a SpatRaster object or geotiff
 file.}
 \usage{
 cqcp_extract_raster_data(lon, lat, raster = NULL, file = NULL)
@@ -12,7 +12,7 @@ cqcp_extract_raster_data(lon, lat, raster = NULL, file = NULL)
 
 \item{lat}{Latitude values(s)}
 
-\item{raster}{RasterLayer object (cf. raster package)}
+\item{raster}{SpatRaster object (cf. terra package)}
 
 \item{file}{Path to a geotiff file}
 }
@@ -20,6 +20,6 @@ cqcp_extract_raster_data(lon, lat, raster = NULL, file = NULL)
 extracted value(s) for given lon/lat
 }
 \description{
-Extract raster value at given position(s) for a RasterLayer Object or geotiff
+Extract raster value(s) at given position(s) from a SpatRaster object or geotiff
 file.
 }


### PR DESCRIPTION
New reworked version without `raster` and `sp` packages, as `rgdal` retires.
Makes now use of the `terra` package.
One new parameter in `cqcp_add_dem_height` (`overwrite_z`).
Small documentation updates. 

Solves #36.